### PR TITLE
delete Alien::libuuid prereq when we do not need it instead of adding it when we do

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Alien::libuuid is now a prerequsite listed in META.json.  If it is not
+    needed it will be removed in the configure stage instead of added if
+    it is needed (gh#10)
 
 0.10      2021-05-10 06:53:27 -0600
   - Check for required symbols, and require

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Graham Ollis <plicease@cpan.org>
 
 # COPYRIGHT AND LICENSE
 
-This software is copyright (c) 2014 by Graham Ollis.
+This software is copyright (c) 2014-2022 by Graham Ollis.
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.

--- a/dist.ini
+++ b/dist.ini
@@ -14,8 +14,6 @@ github_user   = uperl
 workflow = linux
 workflow = macos
 
-diag = +Alien::libuuid
-
 [RemovePrereqs]
 remove = strict
 remove = warnings
@@ -23,19 +21,16 @@ remove = constant
 remove = overload
 remove = Carp
 
-remove = Alien::libuuid
-
 ; comes with FFI::Platypus
 remove = FFI::Platypus::Memory
 
 [Prereqs]
-FFI::Platypus = 0.12
-FFI::CheckLib = 0.06
+FFI::Platypus  = 0.12
+FFI::CheckLib  = 0.06
+Alien::libuuid = 0.05 
 
 [Prereqs / ConfigureRequires]
 FFI::CheckLib = 0.05
 
 [Author::Plicease::Upload]
 cpan = 1
-
-

--- a/inc/mymm.pl
+++ b/inc/mymm.pl
@@ -27,9 +27,9 @@ sub myWriteMakefile
     ]
   );
 
-  unless($lib)
+  if($lib)
   {
-    $args{PREREQ_PM}->{'Alien::libuuid'} = 0.05;
+    delete $args{PREREQ_PM}->{'Alien::libuuid'};
   }
 
   WriteMakefile(%args);


### PR DESCRIPTION
This will improve the river metrics on aliens.